### PR TITLE
Fix deprecated warning message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added 
-- Nothing.
-### Updated 
-- Updated README with instructions for `.gitignore`.
+### Changed
+- Changed `require` to `plugins` in rubocop.yml to fix deprecation warning.
 
 ## [1.0.0] - 2021-09-24
 ### Added 

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,6 +1,6 @@
 # Information for creating the rubocop.yml was taken from this location http://rubocop.readthedocs.io/en/latest/configuration/
 # Rules are taken from rubystyle.guide, Azure, Airbnb's Ruby Style Guide and few top starred projects on Github.
-require:
+plugins:
   - rubocop-rails
   - rubocop-rspec
   - rubocop-performance


### PR DESCRIPTION
When running rubocop the following warnings appear:

```
rubocop-rails extension supports plugin, specify `plugins: rubocop-rails` instead of `require: rubocop-rails`
rubocop-rspec extension supports plugin, specify `plugins: rubocop-rspec` instead of `require: rubocop-rspec`
rubocop-performance extension supports plugin, specify `plugins: rubocop-performance` instead of `require: rubocop-performance` 
rubocop-sequel extension supports plugin, specify `plugins: rubocop-sequel` instead of `require: rubocop-sequel` i
rubocop-thread_safety extension supports plugin, specify `plugins: rubocop-thread_safety` instead of `require: rubocop-thread_safety` 
```

This change will resolve that warning message across all apps using this style guide