### PR TITLE
Revert "Fix deprecated warning message"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Changed
-- Changed `require` to `plugins` in rubocop.yml to fix deprecation warning.
+### Added 
+- Nothing.
+### Updated 
+- Updated README with instructions for `.gitignore`.
 
 ## [1.0.0] - 2021-09-24
 ### Added 

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,6 +1,6 @@
 # Information for creating the rubocop.yml was taken from this location http://rubocop.readthedocs.io/en/latest/configuration/
 # Rules are taken from rubystyle.guide, Azure, Airbnb's Ruby Style Guide and few top starred projects on Github.
-plugins:
+require:
   - rubocop-rails
   - rubocop-rspec
   - rubocop-performance


### PR DESCRIPTION
Reverts patterninc/ruby-style-guide#4

Many Ruby projects are using old versions of Rubocop that do not support the "plugins" keyword. Will upgrade those projects and then release this